### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "pcre"
+description := "Perl Compatible Regular Expressions"
+homepage    := "https://pcre.org/"
+license     := "BSD-3-Clause"
+version     := 8.43 sha256:0b8e7465dc5e98c757cc3650a20a7843ee4c3edf50aaf60bb33fd879690d2c73 https://sourceforge.net/projects/pcre/files/pcre/8.43/pcre-8.43.tar.gz/download


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

